### PR TITLE
chore: bump version to 1.0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.31] - 2026-03-20
+
 ### Changed
 
 - Integrated upstream `main` through the 0.3.2 line while preserving the fork's shared agent registry and fork-only command pipeline.
 - Added shared metadata, packaging, and context support for Trae, Pi Coding Agent, and iFlow CLI.
 - Adopted upstream Codex native-skills migration behavior and JSON/JSONC settings merge coverage without regressing fork-specific layouts.
+- Clarified shared `speckit.pipeline` guidance for Codex-compatible skill workflows and synced plugin install resources with the resulting packaged artifacts.
 
 ## [1.0.30] - 2026-03-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "1.0.30"
+version = "1.0.31"
 description = "Enhanced Specify CLI (Z-WICK fork). Spec-Driven Development toolkit with fork-specific automation, packaging, and agent integrations."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- bump project version to 1.0.31
- record the 1.0.31 changelog entry
- keep the release metadata branch aligned with the published v1.0.31 tag

## Test Plan
- `bash .github/workflows/scripts/verify-plugin-install-resources.sh`
- `uv run pytest`
- shell plugin install smoke test
- GitHub Actions on `3683e25`: Lint / Test & Lint Python / CodeQL all passed
- GitHub Actions `Create Release` for `v1.0.31` succeeded and published assets